### PR TITLE
Feature/17/add afterpray option crawler

### DIFF
--- a/packages/item-crawl/services/option/crawlers.ts
+++ b/packages/item-crawl/services/option/crawlers.ts
@@ -146,6 +146,8 @@ export const _longvacakr = sixshop;
 
 export const _kutletshopcom = sixshop;
 
+export const _afterpraycom = sixshop;
+
 export const _v2koreacokr = (url: string, html: string): OptionCralwer => {
   return new OptionCralwer(url, html)
     .cafe24()

--- a/packages/item-crawl/services/option/crawlers.ts
+++ b/packages/item-crawl/services/option/crawlers.ts
@@ -18,14 +18,20 @@ const makeshop = (url: string, html: string): OptionCralwer => {
 const sixshop = (url: string, html: string): OptionCralwer => {
   return new OptionCralwer(url, html)
     .crawlOptionNames(
-      '#shopProductContentInfo > div.shopProductOptionListDiv > div.productOption > span.custom-select-option-name'
+      '#shopProductContentInfo span.custom-select-option-name',
+      0
     )
     .crawlValues(
-      '#shopProductContentInfo > div.shopProductOptionListDiv > div.productOption > div.customSelectDiv > div.selectBox > div.custom-select-box-list-inner',
-      'div.custom-select-option > div.custom-select-option-info',
+      '#shopProductContentInfo div.productOption > div.customSelectDiv',
+      'div.custom-select-option-info',
       (ele) => (ele as cheerio.TagElement).children[0].data.includes('품절'),
       0,
-      1
+      1,
+      (value) => value.split('(')[0].trim()
+    )
+    .checkitemIsSoldout(
+      '#shopProductCartErrorDiv',
+      (ins) => !ins.hasClass('hide')
     );
 };
 
@@ -138,25 +144,7 @@ export const _aecawhitecom = (url: string, html: string): OptionCralwer => {
 
 export const _longvacakr = sixshop;
 
-export const _kutletshopcom = (url: string, html: string): OptionCralwer => {
-  return new OptionCralwer(url, html)
-    .crawlOptionNames(
-      '#shopProductContentInfo span.custom-select-option-name',
-      0
-    )
-    .crawlValues(
-      '#shopProductContentInfo div.productOption > div.customSelectDiv',
-      'div.custom-select-option-info',
-      (ele) => (ele as cheerio.TagElement).children[0].data.includes('품절'),
-      0,
-      1,
-      (value) => value.split('(')[0].trim()
-    )
-    .checkitemIsSoldout(
-      '#shopProductCartErrorDiv',
-      (ins) => !ins.hasClass('hide')
-    );
-};
+export const _kutletshopcom = sixshop;
 
 export const _v2koreacokr = (url: string, html: string): OptionCralwer => {
   return new OptionCralwer(url, html)


### PR DESCRIPTION
## Description

### 변경사항
1. sixshop 크롤러를 업데이트 합니다. 확인해 보니 kutletshopcom과 afterpraycom 모두 sixshop을 사용하고 있었습니다. kutletshopcom 코드가 더 깔끔하고, 정확해서 기존 sixshop 옵션 크롤러를 _kutletshopcom으로 대체했습니다.
2. _afterpraycom 옵션 크롤러를 추가했습니다.

## Related Issues

resolve #
fix #

## Tests

**I added the following tests:**

(이 부분을 PR에서 작성한/변경한 테스트 파일들의 리스트로 대체해주세요. 조만간 취소될 변경점인 경우 테스트를 작성하지 않아도 됩니다. 이외의 경우 모든 변경/수정된 부분에 대한 테스트가 작성되어야합니다.)

**also deleted deprecated tests for:**

(이 부분을 PR에서 제거한 테스트들의 파일 리스트로 대체해주세요.)

## Checklist

PR을 생성하기 전에 아래에서 만족한 요구사항들의 박스를 체크해주세요. (`[x]`) 원활하고 빠른 리뷰 프로세스를 위해 필요한 과정입니다.

- [x] 모든 **변경점**들을 확인했으며 적절히 알렸습니다.
- [x] Run `npm run test` or `npm run test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
